### PR TITLE
Generalise build_readme() to build_rmd() (#2201)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools (development version)
 
+* New `build_rmd()` can build any `.Rmd` file in a clean session.
+
 # devtools 2.2.2
 
 * `install_dev_deps()` now passes formal args onto `remotes::install_deps()`

--- a/R/install.R
+++ b/R/install.R
@@ -56,7 +56,7 @@ install <-
     # Forcing all of the promises for the current namespace now will avoid lazy-load
     # errors when the new package is installed overtop the old one.
     # https://stat.ethz.ch/pipermail/r-devel/2015-December/072150.html
-    if (is_loaded(pkg)) {
+    if (reload && is_loaded(pkg)) {
       eapply(pkgload::ns_env(pkg$package), force, all.names = TRUE)
     }
 
@@ -93,7 +93,7 @@ install <-
     was_loaded <- is_loaded(pkg)
     was_attached <- is_attached(pkg)
 
-    if (was_loaded) {
+    if (reload && was_loaded) {
       pkgload::unload(pkg$package)
     }
 

--- a/tests/testthat/test-build-readme.R
+++ b/tests/testthat/test-build-readme.R
@@ -3,11 +3,10 @@ context("Build README")
 test_that("Package readme can be built ", {
   skip_on_cran()
 
-  destination <- file.path("testReadme", "README.md")
-
-  on.exit(unlink(c("testReadme/README.md", "testReadme/README.html", "testReadme/man/figures"), recursive = TRUE))
+  on.exit(unlink(c("testReadme/README.md", "testReadme/man/figures"), recursive = TRUE))
 
   build_readme("testReadme")
 
-  expect_true(file.exists(destination))
+  expect_true(file.exists(file.path("testReadme", "README.md")))
+  expect_false(file.exists(file.path("testReadme", "README.html")))
 })


### PR DESCRIPTION
* Don't unload & reload if reload = FALSE

* Implement build_rmd()
  * Installs temporary version of package
  * Builds each Rmd in its own session
  * `build_readme()` now uses `build_rmd()`